### PR TITLE
mrc-3967: Fix integration bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *env
 naomi_bot.egg-info/
 docker/.vault_secrets.ini
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A bot for creating hintr PRs from naomi PRs
 
 When there is a new PR in naomi https://github.com/mrc-ide/naomi which updates the version number this bot will:
-  * Create a new branch in hintr https://github.com/mrc-ide/hintr called naomi-<version_number>
+  * Create a new branch in hintr https://github.com/mrc-ide/hintr called naomi-<branch_name>
   * Update the version of naomi in the `DESCRIPTION`
   * Pin the docker build script to the head branch of the naomi PR
   * Create a PR for the new branch into master

--- a/docker/vault_secrets
+++ b/docker/vault_secrets
@@ -5,7 +5,7 @@ HERE=$(dirname $0)
 export VAULT_ADDR='https://vault.dide.ic.ac.uk:8200'
 vault login -method=github > /dev/null
 WEBHOOK_SECRET=`vault read -field=secret /secret/hint/naomi-bot/webhook-secret`
-GH_AUTH_TOKEN=`vault read -field=token /secret/vimc-robot/github-pat`
+GH_AUTH_TOKEN=`vault read -field=token /secret/hint/naomi-bot/auth-token`
 echo "[vault_secrets]
 WEBHOOK_SECRET=${WEBHOOK_SECRET}
 GH_AUTH_TOKEN=${GH_AUTH_TOKEN}

--- a/docker/vault_secrets
+++ b/docker/vault_secrets
@@ -5,7 +5,7 @@ HERE=$(dirname $0)
 export VAULT_ADDR='https://vault.dide.ic.ac.uk:8200'
 vault login -method=github > /dev/null
 WEBHOOK_SECRET=`vault read -field=secret /secret/hint/naomi-bot/webhook-secret`
-GH_AUTH_TOKEN=`vault read -field=token /secret/vimc/vimc-robot/github-pat`
+GH_AUTH_TOKEN=`vault read -field=token /secret/vimc-robot/github-pat`
 echo "[vault_secrets]
 WEBHOOK_SECRET=${WEBHOOK_SECRET}
 GH_AUTH_TOKEN=${GH_AUTH_TOKEN}

--- a/docker/vault_secrets
+++ b/docker/vault_secrets
@@ -2,10 +2,10 @@
 set -ex
 HERE=$(dirname $0)
 
-export VAULT_ADDR='https://support.montagu.dide.ic.ac.uk:8200'
+export VAULT_ADDR='https://vault.dide.ic.ac.uk:8200'
 vault login -method=github > /dev/null
-WEBHOOK_SECRET=`vault read -field=secret /secret/naomi-bot/webhook-secret`
-GH_AUTH_TOKEN=`vault read -field=token /secret/naomi-bot/auth-token`
+WEBHOOK_SECRET=`vault read -field=secret /secret/hint/naomi-bot/webhook-secret`
+GH_AUTH_TOKEN=`vault read -field=token /secret/vimc/vimc-robot/github-pat`
 echo "[vault_secrets]
 WEBHOOK_SECRET=${WEBHOOK_SECRET}
 GH_AUTH_TOKEN=${GH_AUTH_TOKEN}

--- a/naomi_bot/app/__main__.py
+++ b/naomi_bot/app/__main__.py
@@ -67,7 +67,7 @@ async def main(request):
   event = sansio.Event.from_http(request.headers, body, secret=secret)
 
   async with aiohttp.ClientSession() as session:
-    gh = gh_aiohttp.GitHubAPI(session, "r-ash",
+    gh = gh_aiohttp.GitHubAPI(session, "vimc-robot",
                               oauth_token=oauth_token)
 
     # call the appropriate callback for the event

--- a/naomi_bot/app/__main__.py
+++ b/naomi_bot/app/__main__.py
@@ -19,13 +19,14 @@ async def new_pr_event(event, gh, *args, **kwargs):
   repo_url = "/repos/mrc-ide/hintr"
   naomi_branch = event.data["pull_request"]["head"]["ref"]
   print("Handling new PR for naomi branch " + naomi_branch)
+
+  new_branch = "naomi-" + naomi_branch
   
   description = await gh.getitem(event.data["pull_request"]["head"]["repo"]["url"] + 
     "/contents/DESCRIPTION" + "?ref=" + naomi_branch
   )
   description_text = text_from_base64(description["content"])
   version_number = get_version_number(description_text)
-  new_branch = "naomi-" + version_number
 
   await update_branch(gh, repo_url, version_number, naomi_branch, new_branch)
 

--- a/naomi_bot/app/update_branch.py
+++ b/naomi_bot/app/update_branch.py
@@ -34,7 +34,7 @@ async def update_branch(gh, repo_url, naomi_version, naomi_branch, hintr_new_bra
   
 
   ## Make code change
-  # Update DESCRIPTION - naomi and hintr version?
+  # Update DESCRIPTION - naomi version
   description = await gh.getitem(repo_url + "/contents/DESCRIPTION")
   desc_text = text_from_base64(description["content"])
   new_desc = update_naomi_version(desc_text, naomi_version)


### PR DESCRIPTION
This PR will
* Create hintr branch from Naomi branch name, not the version number. This will hopefully mean if people are making simultaneous changes the PR bot will create a hintr PR for both naomi changes, even if they have the same version number

I'll make another PR after this with some further improvements but this is a good start to get the bot running again.

Can see an example of this working here https://github.com/mrc-ide/naomi/pull/389