### PR TITLE
Remove branch pin from hintr when naomi PR is merged

### DIFF
--- a/naomi_bot/app/__main__.py
+++ b/naomi_bot/app/__main__.py
@@ -71,7 +71,7 @@ async def pr_close_event(event, gh, *args, **kwargs):
 
 
 def get_hintr_branch(naomi_branch):
-  "naomi-" + naomi_branch
+  return "naomi-" + naomi_branch
 
 @routes.post("/naomi-bot/")
 async def main(request):

--- a/naomi_bot/app/update_branch.py
+++ b/naomi_bot/app/update_branch.py
@@ -58,7 +58,7 @@ async def update_branch(gh, repo_url, naomi_version, naomi_branch, hintr_new_bra
   })
 
 async def remove_pin(gh, repo_url, hintr_branch):
-  docker = await gh.getitem(repo_url + "/contents/docker/build")
+  docker = await gh.getitem(repo_url + "/contents/docker/build?ref=refs/heads/" + hintr_branch)
   docker_text = text_from_base64(docker["content"])
   new_docker = remove_branch_pin(docker_text)
   await gh.put(repo_url + "/contents/docker/build", data={

--- a/naomi_bot/app/version.py
+++ b/naomi_bot/app/version.py
@@ -5,7 +5,7 @@ def get_version_number(text):
   if not match:
     raise Exception("Can't read version information")
   else:
-    return(match.group(1))
+    return match.group(1)
 
 def update_naomi_version(text, naomi_version):
   updated_text = re.sub(r'(\s*naomi \(>= )([\d.]+)', r'\g<1>' + naomi_version, text)
@@ -13,7 +13,7 @@ def update_naomi_version(text, naomi_version):
     raise Exception("Failed to update naomi version in text to " + naomi_version +
       " either can't find in file or version is same as what trying to update to")
   else:
-    return(updated_text)
+    return updated_text
 
 def update_docker_build(text, naomi_branch):
   updated_text = re.sub(r'(\s*git clone) (https://github.com/mrc-ide/naomi)', r'\g<1> --single-branch --branch ' + naomi_branch + r' \g<2>', text)
@@ -21,11 +21,12 @@ def update_docker_build(text, naomi_branch):
     raise Exception("Failed to update naomi branch in text to " + naomi_branch +
       " either can't find in file or branch is same as what trying to update to")
   else:
-    return(updated_text)
+    return updated_text
 
 def remove_branch_pin(text):
-  updated_text = re.sub(r'git clone --single-branch --branch (.+) https://github.com/mrc-ide/naomi', r'git clone https://github.com/mrc-ide/naomi', text)
+  updated_text = re.sub(r'git clone --single-branch --branch (.+) https://github.com/mrc-ide/naomi',
+                        r'git clone https://github.com/mrc-ide/naomi', text)
   if updated_text == text:
     raise Exception("Failed to remove branch pin either can't find in file or branch pin")
   else:
-    return(updated_text)
+    return updated_text

--- a/naomi_bot/app/version.py
+++ b/naomi_bot/app/version.py
@@ -22,3 +22,10 @@ def update_docker_build(text, naomi_branch):
       " either can't find in file or branch is same as what trying to update to")
   else:
     return(updated_text)
+
+def remove_branch_pin(text):
+  updated_text = re.sub(r'git clone --single-branch --branch (.+) https://github.com/mrc-ide/naomi', r'git clone https://github.com/mrc-ide/naomi', text)
+  if updated_text == text:
+    raise Exception("Failed to remove branch pin either can't find in file or branch pin")
+  else:
+    return(updated_text)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -77,3 +77,20 @@ def test_update_docker_build():
 
     docker build --pull .
     """, "new-branch")
+
+def test_remove_branch_pin():
+  docker_text = """
+  set -e
+  HERE=$(dirname $0)
+  . $HERE/common
+
+  git clone https://github.com/mrc-ide/naomi
+
+  docker build --pull .
+  """
+
+  text = version.update_docker_build(docker_text, "new-branch")
+  assert version.remove_branch_pin(text) == docker_text
+
+  with pytest.raises(Exception):
+    version.remove_branch_pin(docker_text)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -84,6 +84,7 @@ def test_remove_branch_pin():
   HERE=$(dirname $0)
   . $HERE/common
 
+  rm -rf naomi
   git clone https://github.com/mrc-ide/naomi
 
   docker build --pull .


### PR DESCRIPTION
This PR will
* Add a new route to listen to `pull_request` closed events. If a pull_request was closed and merged then it will remove the branch pin from hintr build script. You can see this working here https://github.com/mrc-ide/hintr/pull/458/commits/ea252df7334607d64faf9d46c9e8e066330a9380